### PR TITLE
Updates AppendEntries Function to Match Raft Paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ You will need to start all the nodes defined in the configuration file for the c
 To connect to a running node so that you can start running your SQL queries, run:
 
 ```sh
-telnet <configured node's client bind address> <configured node's client bind port>
+nc <configured node's client bind address> <configured node's client bind port>
 ```

--- a/consensus/raft/raft.proto
+++ b/consensus/raft/raft.proto
@@ -3,5 +3,8 @@ package raft;
 
 message LogEntry {
     string id = 1;
-    string command = 2;
+    int64 index = 2;
+	int64 term = 3;
+	bool committed = 4;
+    string command = 5;
 }

--- a/consensus/raft/replication.proto
+++ b/consensus/raft/replication.proto
@@ -25,4 +25,5 @@ message LogEntryReplicationStatus {
 message AppendEntriesResponse {
     repeated LogEntryReplicationStatus entryStatuses = 1;
     int64 term = 2;
+    bool success = 3; // true if follower contained entry matching prevLogIndex and prevLogTerm
 }


### PR DESCRIPTION
There were certain steps that need to be done before appending an entry,
as stated in the Raft paper, that weren't being done:

1. Reply false if term < currentTerm (section 5.1)
2. Reply false if log doesn't contain an entry at prevLogIndex whose
   term matches prevLogTerm (section 5.3).
3. If an existing entry conflicts with a new one (same index but
   different terms), delete the existing entry and all that follow it
   (section 5.3).

Having these steps will help with reconciling with a leader in-case of a
conflict between the log of the follower and the leader.

TODO: Add tests to newly added functionality.

Fixes #10