### PR TITLE
Fixs Issues Causing Command Proxying to Fail

### DIFF
--- a/consensus/raft/replication.go
+++ b/consensus/raft/replication.go
@@ -319,9 +319,11 @@ func (node *Node) commitUpToIndex(index int64) error {
 // addLogEntry inserts an entry into the log. The function is also responsible for saving the source address
 // in memory (if the current node is a leader)
 func (node *Node) addLogEntry(sourceAddress stateMachineClient, entry *LogEntry) error {
-	node.logEntryStates[entry.Id] = &logEntryState{
-		numberNodesWithEntry: 0,
+	_, logEntryStateExists := node.logEntryStates[entry.Id]
+	if !logEntryStateExists {
+		node.logEntryStates[entry.Id] = &logEntryState{}
 	}
+	node.logEntryStates[entry.Id].numberNodesWithEntry = 0
 
 	switch entry.Index {
 	case -1:


### PR DESCRIPTION
Fixes the following issues causing command proxying to fail:
 1. Register the previously unregistered ProxyService when the raft node
    is initialized.
 2. Use the same piece of code to process an incoming command in the
    master for when commands are received from a client connected
    directly to the master and for commands proxied from another node.
 3. Prevent the log entry state (in node.logEntryStates) corresponding
    to a log entry from being reset whenever node.addLogEntry is called.

Fixes #4

Signed-off-by: Jason Rogena <jason@rogena.me>